### PR TITLE
Fixes factory service deprecation notices [Symfony 2.x to 3.x]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@ php:
     - 5.3
     - 5.4
     - 5.5
+    - 5.6
     - hhvm
 
 env:
-    - SYMFONY_VERSION=2.1.*
-    - SYMFONY_VERSION=2.2.*
-    - SYMFONY_VERSION=2.3.*
-    - SYMFONY_VERSION=2.4.*
+    - SYMFONY_VERSION=2.6.*
+    - SYMFONY_VERSION=2.7.*
     - SYMFONY_VERSION=dev-master
 
 install: composer install

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" ?>
-
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
@@ -10,7 +9,10 @@
     </parameters>
 
     <services>
-        <service id="davidbadura_faker.faker" class="%davidbadura_faker.faker.class%" factory-class="%davidbadura_faker.factory.class%" factory-method="create" />
-    </services>
+        <service id="davidbadura_faker.factory" class="%davidbadura_faker.factory.class%" />
 
+        <service id="davidbadura_faker.faker" class="%davidbadura_faker.factory.class%">
+            <factory service="davidbadura_faker.factory" method="create" />
+        </service>
+    </services>
 </container>

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }],
     "require": {
         "php": ">=5.3.0",
-        "symfony/symfony" : ">=2.0",
+        "symfony/symfony" : ">=2.6",
         "fzaninotto/faker": "~1.0"
     },
     "autoload": {


### PR DESCRIPTION
Hi,

with Symfony 2.7 i receive a list of deprecation notices. The service definition for factories is changed and the old one is marked as deprecated.

This PR should fix the problem but old version of Symfony are no longer supported.

What do you think about this PR?